### PR TITLE
RUBY-210 - Default client timeout of graph queries to be unlimited

### DIFF
--- a/lib/dse/graph/options.rb
+++ b/lib/dse/graph/options.rb
@@ -38,7 +38,8 @@ module Dse
         :graph_source,
         :graph_language,
         :graph_read_consistency,
-        :graph_write_consistency
+        :graph_write_consistency,
+        :request_timeout
       ].freeze
 
       # Create an Options object.
@@ -49,6 +50,7 @@ module Dse
         @real_options = options.select do |key, _|
           OPTION_NAMES.include?(key)
         end
+        @real_options['request-timeout'] = [options[:timeout] * 1000].pack("Q>") if options[:timeout]
       end
 
       OPTION_NAMES.each do |attr|
@@ -101,7 +103,7 @@ module Dse
         # where the keys are hyphenated (the way the server expects them).
         result = {}
         graph_options.each do |key, value|
-          result[key.to_s.tr!('_', '-')] = value if value
+          result[key.to_s.tr('_', '-')] = value if value
         end
         result
       end
@@ -109,11 +111,7 @@ module Dse
       # @private
       def eql?(other)
         other.is_a?(Options) && \
-          @real_options[:graph_name] == other.graph_name && \
-          @real_options[:graph_source] == other.graph_source && \
-          @real_options[:graph_language] == other.graph_language && \
-          @real_options[:graph_read_consistency] == other.graph_read_consistency && \
-          @real_options[:graph_write_consistency] == other.graph_write_consistency
+          @real_options == other.instance_variable_get(:@real_options)
       end
       alias == eql?
 

--- a/lib/dse/session.rb
+++ b/lib/dse/session.rb
@@ -13,9 +13,6 @@ module Dse
   # @see http://datastax.github.io/ruby-driver/api/cassandra/session Cassandra::Session
   class Session
     # @private
-    DEFAULT_GRAPH_TIMEOUT = 32
-
-    # @private
     def initialize(cassandra_session, graph_options, futures_factory)
       @cassandra_session = cassandra_session
       @graph_options = graph_options
@@ -53,7 +50,7 @@ module Dse
 
       graph_options = @graph_options.merge(graph_statement.options)
       options[:payload] = graph_options.as_payload
-      options[:timeout] = DEFAULT_GRAPH_TIMEOUT unless options[:timeout]
+      options[:timeout] = nil unless options[:timeout]
 
       if graph_options.analytics?
         @cassandra_session.execute_async('CALL DseClientTool.getAnalyticsGraphServer()').then do |rows|

--- a/spec/dse/graph/options_spec.rb
+++ b/spec/dse/graph/options_spec.rb
@@ -128,6 +128,13 @@ module Dse
                                            'graph-source' => 'a',
                                            'graph-language' => 'gremlin-groovy')
         end
+
+        it 'should include request-timeout option if there is a timeout' do
+          options = Dse::Graph::Options.new({ timeout: 7 })
+          expect(options.as_payload).to eq('request-timeout' => [7000].pack("Q>"),
+                                           'graph-source' => 'g',
+                                           'graph-language' => 'gremlin-groovy')
+        end
       end
     end
   end

--- a/spec/dse/session_spec.rb
+++ b/spec/dse/session_spec.rb
@@ -19,8 +19,8 @@ module Dse
       it 'should succeed without query parameters' do
         expected_graph_statement = Dse::Graph::Statement.new('g.V()', nil, graph_options)
         expect(cassandra_session).to receive(:execute_async)
-          .with(expected_graph_statement, timeout: 32,
-                                          payload: { 'graph-source' => 'g', 'graph-language' => 'gremlin-groovy' })
+          .with(expected_graph_statement, timeout: nil,
+                payload: { 'graph-source' => 'g', 'graph-language' => 'gremlin-groovy' })
           .and_return(future)
         expect(future).to receive(:then)
         session.execute_graph_async('g.V()')
@@ -29,7 +29,7 @@ module Dse
       it 'should succeed with query parameters' do
         expected_graph_statement = Dse::Graph::Statement.new('g.V().limit(n)', { n: 2 }, graph_options)
         expect(cassandra_session).to receive(:execute_async)
-          .with(expected_graph_statement, arguments: { n: 2 }, timeout: 32,
+          .with(expected_graph_statement, arguments: { n: 2 }, timeout: nil,
                                           payload: { 'graph-source' => 'g', 'graph-language' => 'gremlin-groovy' })
           .and_return(future)
         expect(future).to receive(:then)
@@ -47,9 +47,9 @@ module Dse
         expect(cassandra_session).to receive(:execute_async)
           .with(expected_graph_statement,
                 execution_options.merge(
-                  payload: { 'graph-source' => 'other', 'graph-language' => 'gremlin-groovy', 'graph-name' => 'myg' },
-                  timeout: 32))
-          .and_return(future)
+                  timeout: nil,
+                  payload: { 'graph-source' => 'other', 'graph-language' => 'gremlin-groovy', 'graph-name' => 'myg' }))
+                                         .and_return(future)
         expect(future).to receive(:then)
         options = Dse::Graph::Options.new
         options.graph_source = 'other'
@@ -63,7 +63,7 @@ module Dse
         options.graph_name = 'myg'
         expected_graph_statement = Dse::Graph::Statement.new('g.V()', nil, options)
         expect(cassandra_session).to receive(:execute_async)
-          .with(expected_graph_statement, graph_options: options, timeout: 32,
+          .with(expected_graph_statement, graph_options: options, timeout: nil,
                                           payload: { 'graph-source' => 'other',
                                                      'graph-language' => 'gremlin-groovy',
                                                      'graph-name' => 'myg' })
@@ -75,8 +75,7 @@ module Dse
       it 'should accept graph statement object' do
         graph_statement = Dse::Graph::Statement.new('g.V()', nil, { graph_name: 'myg' }, true)
         expect(cassandra_session).to receive(:execute_async)
-          .with(graph_statement,
-                random: 'junk', timeout: 32,
+          .with(graph_statement, timeout: nil, random: 'junk',
                 payload: { 'graph-source' => 'g', 'graph-language' => 'gremlin-groovy', 'graph-name' => 'myg' })
           .and_return(future)
         expect(future).to receive(:then)


### PR DESCRIPTION
* This was fixed previously, accidentally got merged to master, got reverted in master, and is now being restored in the 1.0.0 branch.
* Also includes a merge-down from master of recent changes.