### PR TITLE
RUBY-248 - Duration.eql? should check for equivalence, not attribute-…

### DIFF
--- a/lib/dse/graph/duration.rb
+++ b/lib/dse/graph/duration.rb
@@ -83,13 +83,14 @@ module Dse
 
       # @private
       def eql?(other)
-        other.is_a?(Duration) && \
-          @days == other.days && \
-          @hours == other.hours && \
-          @minutes == other.minutes && \
-          @seconds == other.seconds
+        other.is_a?(Duration) && as_seconds == other.as_seconds
       end
       alias == eql?
+
+      # @return [Float] this {Duration} object converted to seconds
+      def as_seconds
+        @seconds + @minutes*60 + @hours*3600 + @days*86400
+      end
 
       # @private
       def hash

--- a/spec/dse/graph/duration_spec.rb
+++ b/spec/dse/graph/duration_spec.rb
@@ -17,6 +17,9 @@ module Dse
         expect(Duration.new(nil, nil, nil, nil).to_s).to eq('P0DT0H0M0.0S')
       end
 
+      it 'should consider equivalent Durations as equal' do
+        expect(Duration.new(1, 2, 3, 4)).to eq(Duration.new(0, 26, 0, 184))
+      end
       context :initialize do
         it 'should coerce nil args to the right types' do
           duration = Duration.new(nil, nil, nil, nil)
@@ -98,6 +101,24 @@ module Dse
 
         it 'should handle partially specified durations' do
           expect(Duration.parse('PT-5S')).to eq(Duration.new(0, 0, 0, -5))
+        end
+      end
+
+      context :as_seconds do
+        it 'should handle 0 duration' do
+          expect(Duration.new(0, 0, 0, 0).as_seconds).to eq(0)
+        end
+
+        it 'should handle positive duration' do
+          expect(Duration.new(1, 2, 3, 4).as_seconds).to eq(86400 + 2*3600 + 180 + 4)
+        end
+
+        it 'should handle negative duration' do
+          expect(Duration.new(-1, -2, -3, -4).as_seconds).to eq(-86400 - 2*3600 - 180 - 4)
+        end
+
+        it 'should handle mixed positive and negative duration' do
+          expect(Duration.new(-1, 2, -3, 4).as_seconds).to eq(-86400 + 2*3600 - 180 + 4)
         end
       end
     end


### PR DESCRIPTION
…by-attribute equality.

* Add as_seconds method to convert Duration to seconds for easy comparison.